### PR TITLE
Repeat mapping CTEs per UPDATE in lease posting rule category sync

### DIFF
--- a/erp-system/man_pages/lease-posting-rules/lease-posting-rule-category-sync.md
+++ b/erp-system/man_pages/lease-posting-rules/lease-posting-rule-category-sync.md
@@ -1,0 +1,19 @@
+# Lease Posting Rule Category Sync (Technical Note)
+
+## Why this update is needed
+Lease posting rules can be created from legacy TA rule screens or from the unified posting rule configuration UI. When the debit or credit transaction accounts in the templates change, the posting rule header must also reflect the account categories of those accounts. This ensures the posting rule header and templates stay consistent, and it keeps downstream rule evaluation aligned with the ledger categories derived from the transaction accounts.
+
+## Workflow summary
+1. Collect TA rule data for every lease contract (interest accrual, interest paid transfer, repayment, and recognition).
+2. Match the TA rules to lease posting rules using the `leaseContractId` posting rule condition and event type.
+3. Update posting rule templates so debit/credit accounts mirror the TA rules.
+4. Update the posting rule header debit/credit account category fields based on the selected transaction accounts.
+5. Normalize the `leaseContractId` condition value so it matches the lease contract in the TA rule.
+
+## Implementation notes
+- The synchronization relies on the posting rule condition key `leaseContractId` with the `EQUALS` operator to associate a posting rule with a lease contract.
+- Only rules with `module = 'LEASE'` are updated.
+- Each posting rule is updated with the account categories derived from `transaction_account.account_category_id`.
+
+## Operational script
+Use the SQL script in `erp-system/queries/lease-posting-rule-category-sync.sql` to apply the update in PostgreSQL once TA rules or posting templates have been modified for existing lease contracts. The script repeats its CTEs for each `UPDATE`, so it can be executed as-is in tools that run each statement independently.

--- a/erp-system/queries/lease-posting-rule-category-sync.sql
+++ b/erp-system/queries/lease-posting-rule-category-sync.sql
@@ -1,0 +1,149 @@
+-- Sync lease posting rules with TA rule debit/credit accounts and account categories.
+--
+-- This script aligns lease-specific posting rules with legacy TA rules by:
+-- 1) Updating templates to use the TA rule debit/credit accounts.
+-- 2) Updating posting rule debit/credit account categories to match the
+--    selected transaction accounts.
+-- 3) Normalizing leaseContractId conditions for the affected posting rules.
+
+WITH ta_rules AS (
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_INTEREST_ACCRUAL'::varchar AS event_type
+    FROM talease_interest_accrual_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_INTEREST_PAID_TRANSFER'::varchar AS event_type
+    FROM tainterest_paid_transfer_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_REPAYMENT'::varchar AS event_type
+    FROM talease_repayment_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_LIABILITY_RECOGNITION'::varchar AS event_type
+    FROM talease_recognition_rule
+),
+lease_rule_map AS (
+    SELECT pr.id AS posting_rule_id,
+        ta.lease_contract_id,
+        ta.debit_id,
+        ta.credit_id
+    FROM trx_account_posting_rule pr
+    JOIN trx_account_posting_rule_condition prc
+        ON prc.posting_rule_id = pr.id
+        AND prc.condition_key = 'leaseContractId'
+        AND prc.condition_operator = 'EQUALS'
+    JOIN ta_rules ta
+        ON ta.lease_contract_id = prc.condition_value::bigint
+        AND pr.event_type = ta.event_type
+    WHERE pr.module = 'LEASE'
+)
+UPDATE trx_account_posting_rule_template template
+SET debit_account_id = mapping.debit_id,
+    credit_account_id = mapping.credit_id
+FROM lease_rule_map mapping
+WHERE template.posting_rule_id = mapping.posting_rule_id;
+
+WITH ta_rules AS (
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_INTEREST_ACCRUAL'::varchar AS event_type
+    FROM talease_interest_accrual_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_INTEREST_PAID_TRANSFER'::varchar AS event_type
+    FROM tainterest_paid_transfer_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_REPAYMENT'::varchar AS event_type
+    FROM talease_repayment_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_LIABILITY_RECOGNITION'::varchar AS event_type
+    FROM talease_recognition_rule
+),
+lease_rule_map AS (
+    SELECT pr.id AS posting_rule_id,
+        ta.lease_contract_id,
+        ta.debit_id,
+        ta.credit_id
+    FROM trx_account_posting_rule pr
+    JOIN trx_account_posting_rule_condition prc
+        ON prc.posting_rule_id = pr.id
+        AND prc.condition_key = 'leaseContractId'
+        AND prc.condition_operator = 'EQUALS'
+    JOIN ta_rules ta
+        ON ta.lease_contract_id = prc.condition_value::bigint
+        AND pr.event_type = ta.event_type
+    WHERE pr.module = 'LEASE'
+)
+UPDATE trx_account_posting_rule pr
+SET debit_account_type_id = debit_account.account_category_id,
+    credit_account_type_id = credit_account.account_category_id
+FROM lease_rule_map mapping
+JOIN transaction_account debit_account
+    ON debit_account.id = mapping.debit_id
+JOIN transaction_account credit_account
+    ON credit_account.id = mapping.credit_id
+WHERE pr.id = mapping.posting_rule_id;
+
+WITH ta_rules AS (
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_INTEREST_ACCRUAL'::varchar AS event_type
+    FROM talease_interest_accrual_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_INTEREST_PAID_TRANSFER'::varchar AS event_type
+    FROM tainterest_paid_transfer_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_REPAYMENT'::varchar AS event_type
+    FROM talease_repayment_rule
+    UNION ALL
+    SELECT lease_contract_id,
+        debit_id,
+        credit_id,
+        'LEASE_LIABILITY_RECOGNITION'::varchar AS event_type
+    FROM talease_recognition_rule
+),
+lease_rule_map AS (
+    SELECT pr.id AS posting_rule_id,
+        ta.lease_contract_id,
+        ta.debit_id,
+        ta.credit_id
+    FROM trx_account_posting_rule pr
+    JOIN trx_account_posting_rule_condition prc
+        ON prc.posting_rule_id = pr.id
+        AND prc.condition_key = 'leaseContractId'
+        AND prc.condition_operator = 'EQUALS'
+    JOIN ta_rules ta
+        ON ta.lease_contract_id = prc.condition_value::bigint
+        AND pr.event_type = ta.event_type
+    WHERE pr.module = 'LEASE'
+)
+UPDATE trx_account_posting_rule_condition condition
+SET condition_value = mapping.lease_contract_id::text
+FROM lease_rule_map mapping
+WHERE condition.posting_rule_id = mapping.posting_rule_id
+    AND condition.condition_key = 'leaseContractId';

--- a/erp-system/user-stories/lease-posting-rules/lease-posting-rule-category-sync.md
+++ b/erp-system/user-stories/lease-posting-rules/lease-posting-rule-category-sync.md
@@ -1,0 +1,16 @@
+# User Story: Sync Lease Posting Rule Categories
+
+## Persona
+**Lease Accounting Administrator** who maintains posting rules and ensures the account categories match the configured debit and credit accounts.
+
+## Scenario
+Lease templates are updated for existing contracts, but the posting rule header categories are out of sync. The administrator needs to align the posting rule header and templates with the TA rule configuration so that postings continue to use the correct categories.
+
+### Steps
+1. Review the lease contract and confirm the TA rules (interest accrual, interest paid transfer, repayment, recognition) are correct.
+2. Ensure each lease posting rule has a `leaseContractId` condition that targets the lease contract.
+3. Run the lease posting rule category sync SQL script.
+4. Refresh the lease posting rule configuration list.
+
+## Expected outcome
+The posting rule templates use the correct debit/credit transaction accounts, and the posting rule header debit/credit categories match the account categories of those accounts.

--- a/man_pages/lease-posting-rules/lease-posting-rule-category-sync.md
+++ b/man_pages/lease-posting-rules/lease-posting-rule-category-sync.md
@@ -1,0 +1,19 @@
+# Lease Posting Rule Category Sync (Technical Note)
+
+## Why this update is needed
+Lease posting rules can be created from legacy TA rule screens or from the unified posting rule configuration UI. When the debit or credit transaction accounts in the templates change, the posting rule header must also reflect the account categories of those accounts. This ensures the posting rule header and templates stay consistent, and it keeps downstream rule evaluation aligned with the ledger categories derived from the transaction accounts.
+
+## Workflow summary
+1. Collect TA rule data for every lease contract (interest accrual, interest paid transfer, repayment, and recognition).
+2. Match the TA rules to lease posting rules using the `leaseContractId` posting rule condition and event type.
+3. Update posting rule templates so debit/credit accounts mirror the TA rules.
+4. Update the posting rule header debit/credit account category fields based on the selected transaction accounts.
+5. Normalize the `leaseContractId` condition value so it matches the lease contract in the TA rule.
+
+## Implementation notes
+- The synchronization relies on the posting rule condition key `leaseContractId` with the `EQUALS` operator to associate a posting rule with a lease contract.
+- Only rules with `module = 'LEASE'` are updated.
+- Each posting rule is updated with the account categories derived from `transaction_account.account_category_id`.
+
+## Operational script
+Use the SQL script in `erp-system/queries/lease-posting-rule-category-sync.sql` to apply the update in PostgreSQL once TA rules or posting templates have been modified for existing lease contracts. The script repeats its CTEs for each `UPDATE`, so it can be executed as-is in tools that run each statement independently.

--- a/user-pages/lease-posting-rule-config.md
+++ b/user-pages/lease-posting-rule-config.md
@@ -21,6 +21,9 @@ The Lease Posting Rule Configuration area lets you review, create, and update le
 2. Update the pre-filled fields, templates, or conditions.
 3. Save to return to the list.
 
+## Syncing account categories after template changes
+When you update a lease posting rule template’s debit or credit account for an existing lease contract, the posting rule header categories must be re-aligned to match the account categories of the selected accounts. Run the lease posting rule category sync SQL script to update the posting rule header categories, templates, and `leaseContractId` conditions after the update is saved. Execute the full script in one go so each statement can rebuild its mapping data.
+
 ## Deleting a rule
 1. From the list, click **Delete** next to the rule.
 2. Confirm the deletion in the dialog.

--- a/user-stories/lease-posting-rules/lease-posting-rule-category-sync.md
+++ b/user-stories/lease-posting-rules/lease-posting-rule-category-sync.md
@@ -1,0 +1,16 @@
+# User Story: Sync Lease Posting Rule Categories
+
+## Persona
+**Lease Accounting Administrator** who maintains posting rules and ensures the account categories match the configured debit and credit accounts.
+
+## Scenario
+Lease templates are updated for existing contracts, but the posting rule header categories are out of sync. The administrator needs to align the posting rule header and templates with the TA rule configuration so that postings continue to use the correct categories.
+
+### Steps
+1. Review the lease contract and confirm the TA rules (interest accrual, interest paid transfer, repayment, recognition) are correct.
+2. Ensure each lease posting rule has a `leaseContractId` condition that targets the lease contract.
+3. Run the lease posting rule category sync SQL script.
+4. Refresh the lease posting rule configuration list.
+
+## Expected outcome
+The posting rule templates use the correct debit/credit transaction accounts, and the posting rule header debit/credit categories match the account categories of those accounts.


### PR DESCRIPTION
### Motivation
- Avoid CTE scope errors when the lease posting rule sync script is executed statement-by-statement by tools that do not preserve CTE scope across separate statements.
- Make the operational expectations for running the script explicit in both technical and user-facing documentation.

### Description
- Duplicate the `ta_rules` / `lease_rule_map` CTE block so each `UPDATE` in `erp-system/queries/lease-posting-rule-category-sync.sql` rebuilds its mapping data and can run independently. 
- Constrain rule matching to `trx_account_posting_rule_condition` entries with `condition_key = 'leaseContractId'` and `condition_operator = 'EQUALS'` when building the map. 
- Add a technical note at `erp-system/man_pages/lease-posting-rules/lease-posting-rule-category-sync.md` and `man_pages/lease-posting-rules/lease-posting-rule-category-sync.md` that explains the script repeats CTEs so it can be executed as-is in tools that run each statement independently. 
- Update the user guide at `user-pages/lease-posting-rule-config.md` and add user-story and operational docs under `erp-system/user-stories` to clarify that the full script should be executed so each statement can rebuild its mapping data.

### Testing
- No automated tests were run for this change because it is an SQL and documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fa096efbc832ea8ee16c2e4f9e325)